### PR TITLE
Result on api exception

### DIFF
--- a/source/dotRMDY.SyncSupport.UnitTests/Services/WebServiceHelperTest.cs
+++ b/source/dotRMDY.SyncSupport.UnitTests/Services/WebServiceHelperTest.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using dotRMDY.SyncSupport.Services.Implementations;
+using dotRMDY.SyncSupport.UnitTests.TestHelpers.Models;
+using dotRMDY.TestingTools;
+using FakeItEasy;
+using FluentAssertions;
+using Refit;
+using Xunit;
+
+namespace dotRMDY.SyncSupport.UnitTests.Services;
+
+public class WebServiceHelperTest : SutSupportingTest<WebServiceHelper>
+{
+	[Fact]
+	public async Task ExecuteCall_WithCancellation_ReturnsResult()
+	{
+		// Arrange
+		var cancellationTokenSource = new CancellationTokenSource();
+		var cancellationToken = cancellationTokenSource.Token;
+		var call = A.Fake<Func<CancellationToken, Task<IApiResponse>>>();
+		var apiResponse = A.Fake<IApiResponse>();
+		A.CallTo(() => call(cancellationToken)).Returns(Task.FromResult(apiResponse));
+
+		// Act
+		var result = await Sut.ExecuteCall(call, cancellationToken);
+
+		// Assert
+		result.Should().NotBeNull();
+		A.CallTo(() => call(cancellationToken)).MustHaveHappenedOnceExactly();
+	}
+
+	[Fact]
+	public async Task ExecuteCall_WithResultObj_ReturnsResult()
+	{
+		// Arrange
+		var cancellationTokenSource = new CancellationTokenSource();
+		var cancellationToken = cancellationTokenSource.Token;
+		var call = A.Fake<Func<CancellationToken, Task<IApiResponse<SuccessResult>>>>();
+		var apiResponse = A.Fake<IApiResponse<SuccessResult>>();
+		A.CallTo(() => call(cancellationToken)).Returns(Task.FromResult(apiResponse));
+		A.CallTo(() => apiResponse.Error).Returns(null);
+		A.CallTo(() => apiResponse.Content).Returns(new SuccessResult
+		{
+			A = "A",
+			B = true,
+			C = 1
+		});
+
+		// Act
+		var result = await Sut.ExecuteCall<SuccessResult>(call, cancellationToken);
+
+		// Assert
+		result.Should().NotBeNull();
+		A.CallTo(() => call(cancellationToken)).MustHaveHappenedOnceExactly();
+		result.Data.Should().NotBeNull();
+		result.Data!.A.Should().Be("A");
+		result.Data!.B.Should().BeTrue();
+		result.Data!.C.Should().Be(1);
+	}
+
+	[Fact]
+	public async Task ExecuteCall_WithError_ReturnsErrorResult_WrongPayload()
+	{
+		// Arrange
+		var cancellationTokenSource = new CancellationTokenSource();
+		var cancellationToken = cancellationTokenSource.Token;
+		var call = A.Fake<Func<CancellationToken, Task<IApiResponse<SuccessResult>>>>();
+		var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+		response.Content = new StringContent("{\"code\":\"code\",\"message\":\"message\",\"technicalMessage\":\"technicalMessage\"}");
+		var refitSettings = new RefitSettings();
+		var apiException = await ApiException.Create(new HttpRequestMessage(), HttpMethod.Get, response, refitSettings);
+		var apiResponse = new ApiResponse<SuccessResult>(response, null, refitSettings, apiException);
+		A.CallTo(() => call(cancellationToken)).ReturnsLazily(() => apiResponse);
+
+		// Act
+		var result = await Sut.ExecuteCall<SuccessResult, ErrorTestResult?>(call, cancellationToken);
+
+		// Assert
+		A.CallTo(() => call(A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+		result.Should().NotBeNull();
+		result.Data.Should().BeNull();
+		result.ErrorData.Should().NotBeNull();
+		result.ErrorData!.Id.Should().BeNull();
+		result.ErrorData!.B.Should().BeNull();
+		result.ErrorData!.C.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task ExecuteCall_WithError_ReturnsErrorResult_CorrectPayload()
+	{
+		// Arrange
+		var cancellationTokenSource = new CancellationTokenSource();
+		var cancellationToken = cancellationTokenSource.Token;
+		var call = A.Fake<Func<CancellationToken, Task<IApiResponse<SuccessResult>>>>();
+		var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+		response.Content = new StringContent(JsonSerializer.Serialize(new ErrorTestResult
+		{
+			Id = "id",
+			B = true,
+			C = 5
+		}));
+		var refitSettings = new RefitSettings();
+		var apiException = await ApiException.Create(new HttpRequestMessage(), HttpMethod.Get, response, refitSettings);
+		var apiResponse = new ApiResponse<SuccessResult>(response, null, refitSettings, apiException);
+		A.CallTo(() => call(cancellationToken)).ReturnsLazily(() => apiResponse);
+
+		// Act
+		var result = await Sut.ExecuteCall<SuccessResult, ErrorTestResult?>(call, cancellationToken);
+
+		// Assert
+		A.CallTo(() => call(A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+		result.Should().NotBeNull();
+		result.Data.Should().BeNull();
+		result.ErrorData.Should().NotBeNull();
+		result.ErrorData!.Id.Should().Be("id");
+		result.ErrorData!.B.Should().BeTrue();
+		result.ErrorData!.C.Should().Be(5);
+	}
+}

--- a/source/dotRMDY.SyncSupport.UnitTests/TestHelpers/Models/ErrorTestResult.cs
+++ b/source/dotRMDY.SyncSupport.UnitTests/TestHelpers/Models/ErrorTestResult.cs
@@ -1,0 +1,8 @@
+namespace dotRMDY.SyncSupport.UnitTests.TestHelpers.Models;
+
+public class ErrorTestResult
+{
+	public string? Id { get; set; }
+	public bool? B { get; set; }
+	public int? C { get; set; }
+}

--- a/source/dotRMDY.SyncSupport.UnitTests/TestHelpers/Models/SuccessResult.cs
+++ b/source/dotRMDY.SyncSupport.UnitTests/TestHelpers/Models/SuccessResult.cs
@@ -1,0 +1,8 @@
+namespace dotRMDY.SyncSupport.UnitTests.TestHelpers.Models;
+
+public class SuccessResult
+{
+	public string? A { get; set; }
+	public bool B { get; set; }
+	public int C { get; set; }
+}

--- a/source/dotRMDY.SyncSupport/Models/CallResult.cs
+++ b/source/dotRMDY.SyncSupport/Models/CallResult.cs
@@ -10,9 +10,9 @@ namespace dotRMDY.SyncSupport.Models
 	/// </summary>
 	public class CallResult
 	{
-		private static readonly CallResult _noConnectionCallResult = new(CallResultStatus.NoConnection);
-		private static readonly CallResult _notAuthenticatedCallResult = new(CallResultStatus.NotAuthenticated);
-		private static readonly CallResult _timeOutCallResult = new(CallResultStatus.TimeOut);
+		private static readonly CallResult NoConnectionCallResult = new(CallResultStatus.NoConnection);
+		private static readonly CallResult NotAuthenticatedCallResult = new(CallResultStatus.NotAuthenticated);
+		private static readonly CallResult TimeOutCallResult = new(CallResultStatus.TimeOut);
 
 		protected CallResult(CallResultStatus status, HttpStatusCode? httpStatusCode = null)
 		{
@@ -50,7 +50,7 @@ namespace dotRMDY.SyncSupport.Models
 		///     Gets the error.
 		/// </summary>
 		/// <value>The error.</value>
-		public CallResultError? Error { get; }
+		protected CallResultError? Error { get; }
 
 		public static CallResult CreateSuccess(HttpStatusCode statusCode)
 		{
@@ -64,17 +64,17 @@ namespace dotRMDY.SyncSupport.Models
 
 		public static CallResult CreateNoConnection()
 		{
-			return _noConnectionCallResult;
+			return NoConnectionCallResult;
 		}
 
 		public static CallResult CreateNotAuthenticated()
 		{
-			return _notAuthenticatedCallResult;
+			return NotAuthenticatedCallResult;
 		}
 
 		public static CallResult CreateTimeOutError()
 		{
-			return _timeOutCallResult;
+			return TimeOutCallResult;
 		}
 
 		public static CallResult Combine(ICollection<CallResult> callResults)
@@ -86,12 +86,12 @@ namespace dotRMDY.SyncSupport.Models
 			}
 
 			var status = CallResultStatus.Success;
-			var stati = callResults.Select(cr => cr.Status).Distinct().ToArray();
-			if (stati.Any(s => s == CallResultStatus.NotAuthenticated))
+			var callResultStatusArray = callResults.Select(cr => cr.Status).Distinct().ToArray();
+			if (callResultStatusArray.Any(s => s == CallResultStatus.NotAuthenticated))
 			{
 				status = CallResultStatus.NotAuthenticated;
 			}
-			else if (stati.Any(s => s == CallResultStatus.NoConnection))
+			else if (callResultStatusArray.Any(s => s == CallResultStatus.NoConnection))
 			{
 				status = CallResultStatus.NoConnection;
 			}
@@ -200,7 +200,7 @@ namespace dotRMDY.SyncSupport.Models
 
 		public static CallResult<T> CreateSuccess<T>(HttpStatusCode statusCode, T data)
 		{
-			return new CallResult<T>(CallResultStatus.Success,  statusCode, data);
+			return new CallResult<T>(CallResultStatus.Success, statusCode, data);
 		}
 
 		public static CallResult<T> CreateError<T>(CallResultError error, HttpStatusCode? statusCode = null)
@@ -221,6 +221,139 @@ namespace dotRMDY.SyncSupport.Models
 		public static CallResult<T> CreateTimeOutError<T>()
 		{
 			return new CallResult<T>(CallResultStatus.TimeOut);
+		}
+	}
+
+	/// <summary>
+	/// Represents a call result with data and error data.
+	/// </summary>
+	/// <typeparam name="TData">The type of the data.</typeparam>
+	/// <typeparam name="TError">The type of the error data.</typeparam>
+	public class CallResult<TData, TError> : CallResult
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="CallResult{TData, TError}"/> class.
+		/// </summary>
+		/// <param name="status">The status of the call result.</param>
+		/// <param name="httpStatusCode">The HTTP status code.</param>
+		/// <param name="data">The data.</param>
+		/// <param name="errorData">The error data.</param>
+		protected CallResult(CallResultStatus status, HttpStatusCode? httpStatusCode = null, TData? data = default, TError? errorData = default)
+			: base(status, httpStatusCode)
+		{
+			Data = data;
+			ErrorData = errorData;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="CallResult{TData, TError}"/> class.
+		/// </summary>
+		/// <param name="error">The error.</param>
+		/// <param name="httpStatusCode">The HTTP status code.</param>
+		/// <param name="data">The data.</param>
+		/// <param name="errorData">The error data.</param>
+		protected CallResult(CallResultError error, HttpStatusCode? httpStatusCode = null, TData? data = default, TError? errorData = default)
+			: base(error, httpStatusCode)
+		{
+			Data = data;
+			ErrorData = errorData;
+		}
+
+		/// <summary>
+		/// Gets the data.
+		/// </summary>
+		public TData? Data { get; }
+
+		/// <summary>
+		/// Gets the error data.
+		/// </summary>
+		public TError? ErrorData { get; }
+
+		/// <summary>
+		/// Maps the call result data to another type.
+		/// </summary>
+		/// <typeparam name="TMappedType">The type of the mapped data.</typeparam>
+		/// <typeparam name="TErrorMapped">The type of the mapped error data.</typeparam>
+		/// <param name="mappedData">The mapped data.</param>
+		/// <param name="mappedErrorData">The mapped error data.</param>
+		/// <returns>A call result with the mapped data.</returns>
+		/// <exception cref="NullReferenceException">Thrown when the mapped data is null.</exception>
+		public CallResult<TMappedType, TErrorMapped> Map<TMappedType, TErrorMapped>(TMappedType? mappedData = null, TErrorMapped? mappedErrorData = null)
+			where TMappedType : class
+			where TErrorMapped : class
+		{
+			return Status switch
+			{
+				CallResultStatus.Success => StatusCode != null && mappedData != null
+					? CreateSuccess<TMappedType, TErrorMapped>(StatusCode.Value, mappedData)
+					: throw new NullReferenceException(nameof(mappedData)),
+				CallResultStatus.Error => CreateError<TMappedType, TErrorMapped>(Error!, mappedErrorData),
+				CallResultStatus.NoConnection => CreateNoConnection<TMappedType, TErrorMapped>(),
+				CallResultStatus.NotAuthenticated => CreateNotAuthenticated<TMappedType, TErrorMapped>(),
+				CallResultStatus.TimeOut => CreateTimeOutError<TMappedType, TErrorMapped>(),
+				_ => throw new ArgumentOutOfRangeException()
+			};
+		}
+
+		/// <summary>
+		/// Creates a successful call result.
+		/// </summary>
+		/// <typeparam name="T">The type of the data.</typeparam>
+		/// <typeparam name="TE">The type of the error data.</typeparam>
+		/// <param name="statusCode">The HTTP status code.</param>
+		/// <param name="data">The data.</param>
+		/// <param name="errorData">The error data.</param>
+		/// <returns>A successful call result.</returns>
+		public static CallResult<T, TE> CreateSuccess<T, TE>(HttpStatusCode statusCode, T data, TE? errorData = default)
+		{
+			return new CallResult<T, TE>(CallResultStatus.Success, statusCode, data, errorData);
+		}
+
+		/// <summary>
+		/// Creates an error call result.
+		/// </summary>
+		/// <typeparam name="T">The type of the data.</typeparam>
+		/// <typeparam name="TE">The type of the error data.</typeparam>
+		/// <param name="error">The error.</param>
+		/// <param name="errorData">The error data.</param>
+		/// <param name="statusCode">The HTTP status code.</param>
+		/// <returns>An error call result.</returns>
+		public static CallResult<T, TE> CreateError<T, TE>(CallResultError error, TE? errorData = default, HttpStatusCode? statusCode = null)
+		{
+			return new CallResult<T, TE>(error, statusCode, default, errorData);
+		}
+
+		/// <summary>
+		/// Creates a call result indicating no connection.
+		/// </summary>
+		/// <typeparam name="T">The type of the data.</typeparam>
+		/// <typeparam name="TE">The type of the error data.</typeparam>
+		/// <returns>A call result indicating no connection.</returns>
+		public static CallResult<T, TE> CreateNoConnection<T, TE>()
+		{
+			return new CallResult<T, TE>(CallResultStatus.NoConnection);
+		}
+
+		/// <summary>
+		/// Creates a call result indicating not authenticated.
+		/// </summary>
+		/// <typeparam name="T">The type of the data.</typeparam>
+		/// <typeparam name="TE">The type of the error data.</typeparam>
+		/// <returns>A call result indicating not authenticated.</returns>
+		public static CallResult<T, TE> CreateNotAuthenticated<T, TE>()
+		{
+			return new CallResult<T, TE>(CallResultStatus.NotAuthenticated);
+		}
+
+		/// <summary>
+		/// Creates a call result indicating a timeout error.
+		/// </summary>
+		/// <typeparam name="T">The type of the data.</typeparam>
+		/// <typeparam name="TE">The type of the error data.</typeparam>
+		/// <returns>A call result indicating a timeout error.</returns>
+		public static CallResult<T, TE> CreateTimeOutError<T, TE>()
+		{
+			return new CallResult<T, TE>(CallResultStatus.TimeOut);
 		}
 	}
 }

--- a/source/dotRMDY.SyncSupport/Services/IWebServiceHelper.cs
+++ b/source/dotRMDY.SyncSupport/Services/IWebServiceHelper.cs
@@ -46,11 +46,10 @@ namespace dotRMDY.SyncSupport.Services
 		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <param name="callerMethod">The name of the calling method.</param>
 		/// <returns>A task representing the asynchronous operation, with a <see cref="CallResult{T, TE}"/> as the result.</returns>
-		Task<CallResult<T, TE>> ExecuteCall<T, TE>(
-			Func<CancellationToken, Task<IApiResponse<T>>> call,
+		Task<CallResult<T, TE>> ExecuteCall<T, TE>(Func<CancellationToken, Task<IApiResponse<T>>> call,
 			CancellationToken cancellationToken = default,
 			[CallerMemberName] string? callerMethod = null)
-			where T : class
-			where TE : class;
+			where T : class?
+			where TE : class?;
 	}
 }

--- a/source/dotRMDY.SyncSupport/Services/IWebServiceHelper.cs
+++ b/source/dotRMDY.SyncSupport/Services/IWebServiceHelper.cs
@@ -11,15 +11,46 @@ namespace dotRMDY.SyncSupport.Services
 	[PublicAPI]
 	public interface IWebServiceHelper
 	{
+		/// <summary>
+		/// Executes a web service call and returns the result.
+		/// </summary>
+		/// <typeparam name="T">The type of the expected result.</typeparam>
+		/// <param name="call">The function representing the API call.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <param name="callerMethod">The name of the calling method.</param>
+		/// <returns>A task representing the asynchronous operation, with a <see cref="CallResult{T}"/> as the result.</returns>
 		Task<CallResult<T>> ExecuteCall<T>(
 			Func<CancellationToken, Task<IApiResponse<T>>> call,
 			CancellationToken cancellationToken = default,
 			[CallerMemberName] string? callerMethod = null)
 			where T : class;
 
+		/// <summary>
+		/// Executes a web service call and returns the result.
+		/// </summary>
+		/// <param name="call">The function representing the API call.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <param name="callerMethod">The name of the calling method.</param>
+		/// <returns>A task representing the asynchronous operation, with a <see cref="CallResult"/> as the result.</returns>
 		Task<CallResult> ExecuteCall(
 			Func<CancellationToken, Task<IApiResponse>> call,
 			CancellationToken cancellationToken = default,
 			[CallerMemberName] string? callerMethod = null);
+
+		/// <summary>
+		/// Executes a web service call and returns the result with error data.
+		/// </summary>
+		/// <typeparam name="T">The type of the expected result.</typeparam>
+		/// <typeparam name="TE">The type of the error data.</typeparam>
+		/// <param name="call">The function representing the API call.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <param name="callerMethod">The name of the calling method.</param>
+		/// <returns>A task representing the asynchronous operation, with a <see cref="CallResult{T, TE}"/> as the result.</returns>
+		Task<CallResult<T, TE>> ExecuteCall<T, TE>(
+			Func<CancellationToken, Task<IApiResponse<T>>> call,
+			CancellationToken cancellationToken = default,
+			[CallerMemberName] string? callerMethod = null)
+			where T : class
+			where TE : class;
 	}
 }


### PR DESCRIPTION
This change enables the ability to parse and use data returned for API calls that were not successful.
